### PR TITLE
Report new external identifiers and other properties separately

### DIFF
--- a/newProperties.py
+++ b/newProperties.py
@@ -25,6 +25,7 @@ payload = {
 
 r = requests.get('https://www.wikidata.org/w/api.php', params=payload)
 data = r.json()
+data['query']['recentchanges'].sort(key=lambda m: m['pageid'])
 
 if len(data['query']['recentchanges']) == 0:
     text = 'none'

--- a/newProperties.py
+++ b/newProperties.py
@@ -27,22 +27,22 @@ r = requests.get('https://www.wikidata.org/w/api.php', params=payload)
 data = r.json()
 data['query']['recentchanges'].sort(key=lambda m: m['pageid'])
 
-if len(data['query']['recentchanges']) == 0:
-    text = 'none'
-else:
-    props = []
-    for m in data['query']['recentchanges']:
-        entity = pywikibot.PropertyPage(repo, m['title'].replace('Property:', ''))
-        entity.get()
-        if 'en' in entity.labels:
-            props.append('[[:d:{0}|{1}]]'.format(m['title'], entity.labels['en']))
-        else:
-            props.append('[[:d:{0}|{1}]]'.format(m['title'], m['title'].replace('Property:', '')))
-    text = ', '.join(props)
+externalIdProps = []
+otherProps = []
+for m in data['query']['recentchanges']:
+    entity = pywikibot.PropertyPage(repo, m['title'].replace('Property:', ''))
+    entity.get()
+    label = entity.labels['en'] if 'en' in entity.labels else m['title'].replace('Property:', '')
+    props = externalIdProps if entity.type == 'external-id' else otherProps
+    props.append('[[:d:{0}|{1}]]'.format(m['title'], label))
+externalIdText = ', '.join(externalIdProps) if externalIdProps else 'none'
+otherText = ', '.join(otherProps) if otherProps else 'none'
 
 header = '<!-- NEW PROPERTIES DO NOT REMOVE -->'
 footer = '<!-- END NEW PROPERTIES -->'
-pretext = '* Newest [[d:Special:ListProperties|properties]]: '
+text = '* Newest [[d:Special:ListProperties|properties]]:\n' + \
+       '** Other datatypes: ' + otherText + '\n' + \
+       '** External identifiers: ' + externalIdText
 
-newtext = re.sub(header + '.*' + footer, header + '\n' + pretext + text + '\n' + footer, page.get(), flags=re.DOTALL)
+newtext = re.sub(header + '.*' + footer, header + '\n' + text + '\n' + footer, page.get(), flags=re.DOTALL)
 page.put(newtext, 'Bot: Updating list of new properties')


### PR DESCRIPTION
This splits the new properties between external identifiers and everything else, and lists them in separate sections of the page. This has been requested several times in the past, e. g. in [this email](https://lists.wikimedia.org/pipermail/wikidata/2017-October/011261.html).

Tested by running everything except the last line in PAWS.

(The other commit is just a minor thing – an improvement IMHO, but feel free to decline it.)