### PR TITLE
Fix warning

### DIFF
--- a/propertyProposalArchive.py
+++ b/propertyProposalArchive.py
@@ -102,7 +102,7 @@ def main():
                     continue
                 for status in stati:
                     status = status if status != 'not done' else ''
-                    history = page2.getVersionHistory()
+                    history = list(page2.revisions())
                     if (today - history[0].timestamp).days >= 1:
                         month = str(history[0].timestamp.month) if history[0].timestamp.month > 9 else '0'+str(history[0].timestamp.month)
                         data = {


### PR DESCRIPTION
getVersionHistory is deprecated since around 5 years. While this still
work, it is better to use newer code in case it get removed