### PR TITLE
Show the exception

### DIFF
--- a/propertyProposalArchive.py
+++ b/propertyProposalArchive.py
@@ -116,7 +116,10 @@ def main():
                             'archive': str(history[0].timestamp.year)+'/'+month
                         }
                         toArchive.append(data)
-            except:
+            except Exception as e:
+                print(proposal)
+                print(type(e))
+                print(e)
                 pass
     if len(toArchive) > 0:
         updateArchive(toArchive)


### PR DESCRIPTION
Since try/except without print do hide syntax error, and shouldn't
be used, it should at least show what is broken so people can fix
it in the code.