### PR TITLE
Make popularItems.py generate RTL aware page

### DIFF
--- a/popularItems.py
+++ b/popularItems.py
@@ -82,7 +82,7 @@ for q in sorted:
             if 'P18' in data['claims']:
                 if data['claims']['P18'][0]['mainsnak']['snaktype'] == 'value':
                     img = data['claims']['P18'][0]['mainsnak']['datavalue']['value']
-                    text = '<span style="float:right; padding-top:0.5em; padding-left:0.5em;">[[File:{}|100px]]</span>\n{} ({{{{I18n|pictured}}}})'.format(img, text)
+                    text = '<span style="float: {{dir|{{{lang|{{int:lang}}}}}|left|right}}; padding-top: 0.5em; padding-{{dir|{{{lang|{{int:lang}}}}}|right|left}}: 0.5em;">[[File:%s|100px]]</span>\n%s ({{{{I18n|pictured}}}})' % (img, text)
     i += 1
     if i == 7:
         break
@@ -90,7 +90,7 @@ for q in sorted:
 
 if not img:
     text = '<nowiki></nowiki>\n' + text
-text += '<span style="clear:right;"></span>'
+text += '<span style="clear: {{dir|{{{lang|{{int:lang}}}}}|left|right}};"></span>'
 
 page = pywikibot.Page(site, 'Wikidata:Main Page/Popular')
 page.put(text, summary='upd', minorEdit=False)


### PR DESCRIPTION
This makes popularItems.py able to generate a result similar to what is changed [here](https://www.wikidata.org/?diff=1459971301&oldid=1459734525), to see why such thing is needed one should visit Wikidata in a RTL language, [for example](https://www.wikidata.org/wiki/Wikidata:Main_Page?uselang=fa) with my change reverted, tested the script locally to check whether it generates what it should.

Tldr:

This change turns 
<img width="657" alt="image" src="https://user-images.githubusercontent.com/833473/126151051-4049730d-d9f0-4eb0-94f3-3784213c4841.png">

to

<img width="619" alt="image" src="https://user-images.githubusercontent.com/833473/126151208-e1fec859-d5d4-4a6f-84e2-cf50706487fd.png">

In https://www.wikidata.org/wiki/Wikidata:Main_Page?uselang=fa
